### PR TITLE
<bug> fix stats decimal precision

### DIFF
--- a/src/components/custom-components/analytics/analytics.tsx
+++ b/src/components/custom-components/analytics/analytics.tsx
@@ -97,7 +97,9 @@ export default function Analytics() {
             <div className="bg-white/20 rounded-lg p-4 flex items-center justify-between">
               <div>
                 <p className="text-sm text-indigo-200">Lowest Score</p>
-                <p className="text-2xl font-bold text-white">{stats.lowest}</p>
+                <p className="text-2xl font-bold text-white">
+                  {stats.lowest.toFixed(2)}
+                </p>
               </div>
               <TrendingDown className="text-red-400" size={24} />
             </div>


### PR DESCRIPTION
Sometimes the lowest score analytic would have some float mishaps and represent 62 as 62.00000 (example). Clamping this analytic to 2 decimal places in this fix.